### PR TITLE
use/reset voicings

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -42,7 +42,7 @@
           style="width: 100%"
         >
           <button
-            v-for="tonic in tonics" 
+            v-for="tonic in tonics"
             :key="tonic"
             :class="['btn', (currentTonic === tonic) ? 'btn-secondary' : 'btn-outline-secondary']"
             @click.stop="setTonic(tonic)"
@@ -60,7 +60,7 @@
         </button>
         <div class="btn-group">
           <button
-            v-for="scaleType in scaleTypes" 
+            v-for="scaleType in scaleTypes"
             :key="scaleType"
             :class="['btn', (currentScaleType === scaleType) ? 'btn-secondary' : 'btn-outline-secondary']"
             @click.stop="setScaleType(scaleType)"
@@ -70,7 +70,7 @@
         </div>
         <div class="btn-group">
           <button
-            v-for="chordType in chordTypes" 
+            v-for="chordType in chordTypes"
             :key="chordType"
             :class="['btn', (currentChordType === chordType) ? 'btn-secondary' : 'btn-outline-secondary']"
             @click.stop="setChordType(chordType)"
@@ -87,26 +87,18 @@
         <button
           class="btn btn-outline-secondary"
           style="line-height: 1em;"
-          :title="$t('saveImage')"
-          @click.stop="downloadImage()"
+          :title="$t('useVoicing')"
+          @click.stop="useVoicing()"
         >
-          <svg
-            width="1em"
-            height="1em"
-            viewBox="0 0 16 16"
-            class="bi bi-download"
-            fill="currentColor"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              fill-rule="evenodd"
-              d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z"
-            />
-            <path
-              fill-rule="evenodd"
-              d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3z"
-            />
-          </svg>
+          {{ $t('useVoicing-short') }}
+        </button>
+        <button
+                class="btn btn-outline-secondary"
+                style="line-height: 1em;"
+                :title="$t('resetVoicing')"
+                @click.stop="resetVoicing()"
+        >
+          {{ $t('resetVoicing-short') }}
         </button>
         <button
           :class="['btn', 'btn-outline-secondary', showSettings ? 'active' : null]"
@@ -336,6 +328,35 @@
 
       downloadImage() {
         this.$refs.keyboard.downloadImage()
+      },
+
+      useVoicing() {
+          const selected = this.$refs.keyboard.fetchSelected();
+          const pitches = [];
+          for (let c in selected) {
+              if (selected[c]) pitches.push(c);
+          }
+
+          const chord = `${this.currentTonic}${this.currentChordType}`;
+
+          const left = [ "left-open", "left-close" ];
+          const right = [ "right-open", "left-close" ];
+          const variants = {
+              "left-open": left,
+              "left-close": left,
+              "right-open": right,
+              "right-close": right,
+          };
+
+          for (const variant of variants[this.currentVariant]) {
+              this.$store.state.chords[variant][chord] = pitches;
+          }
+
+          window.localStorage.setItem('chords', JSON.stringify(this.$store.state.chords));
+      },
+      resetVoicing() {
+        this.$store.state.chords = JSON.parse(JSON.stringify(this.$store.state.originalChords));
+        window.localStorage.removeItem('chords');
       },
     },
   }

--- a/src/components/VKeyboard.vue
+++ b/src/components/VKeyboard.vue
@@ -14,7 +14,7 @@
         :key="tonal"
         @click="toggle(tonal)"
       >
-        <circle 
+        <circle
           :cx="x + 29"
           :cy="y + 29"
           r="28"
@@ -228,6 +228,10 @@
         }
       },
 
+      fetchSelected() {
+        return this.userSelected
+      },
+
       downloadImage() {
         // https://mybyways.com/blog/convert-svg-to-png-using-your-browser
 
@@ -249,7 +253,7 @@
           if (this.scaleType) selected += '-' + this.scaleType
         }
 
-        const filename = 'bandoneon-' 
+        const filename = 'bandoneon-'
           + this.$store.state.instrument + '-'
           + this.currentVariant
           + selected

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -18,5 +18,9 @@
   "built": "Gebaut mit {tonal}, {vuejs} und {bootstrap}.",
   "available": "Verfügbar auf {github}.",
   "helmholtz": "Helmholtz-Tonsymbole (c♯’’)",
-  "scientific": "Wissenschaftliche Tonsymbole (C♯5)"
+  "scientific": "Wissenschaftliche Tonsymbole (C♯5)",
+  "useVoicing": "Use voicing",
+  "useVoicing-short": "Use",
+  "resetVoicing": "Reset voicing",
+  "resetVoicing-short": "Reset"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3,9 +3,9 @@
   "left-close": "Left close",
   "right-open": "Right open",
   "right-close": "Right close",
-  "major": "major",
-  "minor": "minor",
-  "chromatic": "chrom.",
+  "major": "maj",
+  "minor": "min",
+  "chromatic": "chrom",
   "colors": "Colors",
   "settings": "Settings",
   "saveImage": "Save image",
@@ -18,5 +18,9 @@
   "built": "Built with {tonal}, {vuejs}, and {bootstrap}.",
   "available": "Available on {github}.",
   "helmholtz": "Helmholtz pitch notation (c♯’’)",
-  "scientific": "Scientific pitch notation (C♯5)"
+  "scientific": "Scientific pitch notation (C♯5)",
+  "useVoicing": "Use voicing",
+  "useVoicing-short": "Use",
+  "resetVoicing": "Reset voicing",
+  "resetVoicing-short": "Reset"
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -18,5 +18,9 @@
   "built": "Creado con {tonal}, {vuejs} y {bootstrap}.",
   "available": "Disponible en {github}.",
   "helmholtz": "Notación musical de Helmholtz (c♯’’)",
-  "scientific": "Notación musical cientifica (C♯5)"
+  "scientific": "Notación musical cientifica (C♯5)",
+  "useVoicing": "Utilizar voces",
+  "useVoicing-short": "Utilizar",
+  "resetVoicing": "Resetear voces",
+  "resetVoicing-short": "Resetear"
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,7 +2,7 @@ import Vue from "vue"
 import Vuex from "vuex"
 import VueLocalStorage from 'vue-localstorage'
 
-import chords from './chords.json'
+import originalChords from './chords.json'
 import instruments from './instruments'
 
 Vue.use(Vuex)
@@ -12,7 +12,8 @@ export default new Vuex.Store({
   state: () => ({
     language: Vue.localStorage.get('language') || navigator.language?.split('-')[0] || 'en',
     colors: false,
-    chords,
+    chords: (Vue.localStorage.get('chords') && JSON.parse(Vue.localStorage.get('chords'))) || JSON.parse(JSON.stringify(originalChords)),
+    originalChords,
     enharmonic: false,
     instruments,
     instrument: Vue.localStorage.get('instrument') || 'rheinische142',


### PR DESCRIPTION
Hi Nico,

Your tool is wonderful but most often I find don't want the default voicings for the chords. This changeset allows altered voicings to be persisted; also the voicings become common between opening and closing, which is really nice for figuring out how to deal with direction changes. The "use" button saves the current selection against the current chord. The "reset" button reverts all chords to the original voicings. Translations are dodgy (I'm not sure what "voicings" is in Spanish and don't know the German at all...), so the changeset is not ready for your production yet but should not be too far off.

Feel free to abandon the pull request if it doesn't fit with your philosophy.

Regards,
Jamie